### PR TITLE
NAT Network Support

### DIFF
--- a/src/ch/ch_conf.h
+++ b/src/ch/ch_conf.h
@@ -22,6 +22,7 @@
 
 #include "virdomainobjlist.h"
 #include "virthread.h"
+#include "virebtables.h"
 
 #define CH_DRIVER_NAME "CH"
 #define CH_CMD "cloud-hypervisor"
@@ -42,6 +43,8 @@ struct _virCHDriverConfig {
     char *logDir;
 
     int cgroupControllers;
+
+    bool macFilter;
 };
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(virCHDriverConfig, virObjectUnref);
@@ -71,6 +74,9 @@ struct _virCHDriver
     /* Require lock to get reference on 'config',
      * then lockless thereafter */
     virCHDriverConfigPtr config;
+
+    /* Immutable pointer, lockless APIs. Pointless abstraction */
+    ebtablesContext *ebtables;
 
     /* pid file FD, ensures two copies of the driver can't use the same root */
     int lockFD;

--- a/src/ch/ch_domain.h
+++ b/src/ch/ch_domain.h
@@ -68,6 +68,9 @@ struct _virCHDomainObjPrivate {
     virBitmapPtr autoCpuset;
 
     virCgroupPtr cgroup;
+
+    size_t tapfdSize;
+    int *tapfd;
 };
 
 #define CH_DOMAIN_PRIVATE(vm) \

--- a/src/ch/ch_interface.c
+++ b/src/ch/ch_interface.c
@@ -1,0 +1,126 @@
+#include "ch_interface.h"
+#include "domain_nwfilter.h"
+#include "virnetdev.h"
+#include "virnetdevtap.h"
+#include "network_conf.h"
+#include "virlog.h"
+#include "viralloc.h"
+#include "domain_audit.h"
+#include "virnetdevbridge.h"
+#include "virebtables.h"
+#include "virfile.h"
+#include <fcntl.h>
+
+#define VIR_FROM_THIS VIR_FROM_CH
+
+VIR_LOG_INIT("ch.ch_interface");
+
+/* chInterfaceBridgeConnect:
+ * @def: the definition of the VM
+ * @driver: qemu driver data
+ * @net: pointer to the VM's interface description
+ * @tapfd: array of file descriptor return value for the new device
+ * @tapfdsize: number of file descriptors in @tapfd
+ *
+ * Called *only* called if actualType is VIR_DOMAIN_NET_TYPE_NETWORK or
+ * VIR_DOMAIN_NET_TYPE_BRIDGE (i.e. if the connection is made with a tap
+ * device connecting to a bridge device)
+ */
+int
+chInterfaceBridgeConnect(virDomainDefPtr def,
+                           virCHDriverPtr driver,
+                           virDomainNetDefPtr net,
+                           int *tapfd,
+                           size_t *tapfdSize)
+{
+    const char *brname;
+    int ret = 0;
+    unsigned int tap_create_flags = VIR_NETDEV_TAP_CREATE_IFUP;
+    bool template_ifname = false;
+    virCHDriverConfigPtr cfg = virCHDriverGetConfig(driver);
+    const char *tunpath = "/dev/net/tun";
+
+    if (net->backend.tap) {
+        tunpath = net->backend.tap;
+        if (!driver->privileged) {
+            virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
+                           _("cannot use custom tap device in session mode"));
+            goto cleanup;
+        }
+    }
+
+    if (!(brname = virDomainNetGetActualBridgeName(net))) {
+        virReportError(VIR_ERR_INTERNAL_ERROR, "%s", _("Missing bridge name"));
+        goto cleanup;
+    }
+
+    if (!net->ifname ||
+        STRPREFIX(net->ifname, VIR_NET_GENERATED_TAP_PREFIX) ||
+        strchr(net->ifname, '%')) {
+        VIR_FREE(net->ifname);
+        net->ifname = g_strdup(VIR_NET_GENERATED_TAP_PREFIX "%d");
+        /* avoid exposing vnet%d in getXMLDesc or error outputs */
+        template_ifname = true;
+    }
+
+    if (virDomainNetIsVirtioModel(net))
+        tap_create_flags |= VIR_NETDEV_TAP_CREATE_VNET_HDR;
+
+    if (driver->privileged) {
+        if (virNetDevTapCreateInBridgePort(brname, &net->ifname, &net->mac,
+                                           def->uuid, tunpath, tapfd, *tapfdSize,
+                                           virDomainNetGetActualVirtPortProfile(net),
+                                           virDomainNetGetActualVlan(net),
+                                           virDomainNetGetActualPortOptionsIsolated(net),
+                                           net->coalesce, 0, NULL,
+                                           tap_create_flags) < 0) {
+            virDomainAuditNetDevice(def, net, tunpath, false);
+            goto cleanup;
+        }
+        if (virDomainNetGetActualBridgeMACTableManager(net)
+            == VIR_NETWORK_BRIDGE_MAC_TABLE_MANAGER_LIBVIRT) {
+            /* libvirt is managing the FDB of the bridge this device
+             * is attaching to, so we need to turn off learning and
+             * unicast_flood on the device to prevent the kernel from
+             * adding any FDB entries for it. We will add an fdb
+             * entry ourselves (during qemuInterfaceStartDevices(),
+             * using the MAC address from the interface config.
+             */
+            if (virNetDevBridgePortSetLearning(brname, net->ifname, false) < 0)
+                goto cleanup;
+            if (virNetDevBridgePortSetUnicastFlood(brname, net->ifname, false) < 0)
+                goto cleanup;
+        }
+    } else {
+            virReportError(VIR_ERR_OPERATION_UNSUPPORTED, "%s",
+                           _("Cannot connect to bridge in session mode"));
+            goto cleanup;
+    }
+
+    virDomainAuditNetDevice(def, net, tunpath, true);
+
+    if (cfg->macFilter &&
+        ebtablesAddForwardAllowIn(driver->ebtables,
+                                  net->ifname,
+                                  &net->mac) < 0)
+        goto cleanup;
+
+    if (net->filter &&
+        virDomainConfNWFilterInstantiate(def->name, def->uuid, net, false) < 0) {
+        goto cleanup;
+    }
+
+    ret = 0;
+
+ cleanup:
+    if (ret < 0) {
+        size_t i;
+        for (i = 0; i < *tapfdSize && tapfd[i] >= 0; i++)
+            VIR_FORCE_CLOSE(tapfd[i]);
+        if (template_ifname)
+            VIR_FREE(net->ifname);
+    }
+    virObjectUnref(cfg);
+
+    return ret;
+}

--- a/src/ch/ch_interface.c
+++ b/src/ch/ch_interface.c
@@ -57,7 +57,7 @@ chInterfaceBridgeConnect(virDomainDefPtr def,
     if (!net->ifname ||
         STRPREFIX(net->ifname, VIR_NET_GENERATED_TAP_PREFIX) ||
         strchr(net->ifname, '%')) {
-        VIR_FREE(net->ifname);
+        g_free(net->ifname);
         net->ifname = g_strdup(VIR_NET_GENERATED_TAP_PREFIX "%d");
         /* avoid exposing vnet%d in getXMLDesc or error outputs */
         template_ifname = true;
@@ -92,6 +92,9 @@ chInterfaceBridgeConnect(virDomainDefPtr def,
                 goto cleanup;
         }
     } else {
+            /*
+             *  Supporting non-privileged mode, session mode not supported
+             */
             virReportError(VIR_ERR_OPERATION_UNSUPPORTED, "%s",
                            _("Cannot connect to bridge in session mode"));
             goto cleanup;
@@ -118,7 +121,7 @@ chInterfaceBridgeConnect(virDomainDefPtr def,
         for (i = 0; i < *tapfdSize && tapfd[i] >= 0; i++)
             VIR_FORCE_CLOSE(tapfd[i]);
         if (template_ifname)
-            VIR_FREE(net->ifname);
+            g_free(net->ifname);
     }
     virObjectUnref(cfg);
 

--- a/src/ch/ch_interface.h
+++ b/src/ch/ch_interface.h
@@ -1,0 +1,8 @@
+#include "domain_conf.h"
+#include "ch_conf.h"
+
+int chInterfaceBridgeConnect(virDomainDefPtr def,
+                           virCHDriverPtr driver,
+                           virDomainNetDefPtr net,
+                           int *tapfd,
+                           size_t *tapfdSize);

--- a/src/ch/ch_process.c
+++ b/src/ch/ch_process.c
@@ -384,7 +384,6 @@ chProcessNetworkPrepareDevices(virCHDriverPtr driver, virDomainObjPtr vm)
     size_t i;
     virCHDomainObjPrivatePtr priv = vm->privateData;
     g_autoptr(virConnect) conn = NULL;
-    char **tapfdName = NULL;
     int *tapfd = NULL;
     size_t tapfdSize = 0;
 
@@ -397,10 +396,12 @@ chProcessNetworkPrepareDevices(virCHDriverPtr driver, virDomainObjPtr vm)
          * to the one defined in the network definition.
          */
         if (net->type == VIR_DOMAIN_NET_TYPE_NETWORK) {
-            if (!conn && !(conn = virGetConnectNetwork())){
-                return -1;}
-            if (virDomainNetAllocateActualDevice(conn, def, net) < 0){
-                return -1;}
+            if (!conn && !(conn = virGetConnectNetwork())) {
+                return -1;
+            }
+            if (virDomainNetAllocateActualDevice(conn, def, net) < 0) {
+                return -1;
+            }
         }
 
         actualType = virDomainNetGetActualType(net);
@@ -437,9 +438,7 @@ chProcessNetworkPrepareDevices(virCHDriverPtr driver, virDomainObjPtr vm)
                 tapfdSize = 2; //This needs to be at least 2, based on
                 // https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/docs/networking.md
 
-            if (VIR_ALLOC_N(tapfd, tapfdSize) < 0 ||
-                VIR_ALLOC_N(tapfdName, tapfdSize) < 0)
-                goto cleanup;
+            tapfd = g_new(int, tapfdSize);
 
             memset(tapfd, -1, tapfdSize * sizeof(tapfd[0]));
 
@@ -454,11 +453,10 @@ chProcessNetworkPrepareDevices(virCHDriverPtr driver, virDomainObjPtr vm)
          }
     }
 
-return 0;
+    return 0;
 
-cleanup:
-    VIR_FREE(tapfd);
-    VIR_FREE(tapfdName);
+    cleanup:
+        g_free(tapfd);
     return 0;
 }
 

--- a/src/ch/meson.build
+++ b/src/ch/meson.build
@@ -11,6 +11,8 @@ ch_driver_sources = [
   'ch_monitor.h',
   'ch_process.c',
   'ch_process.h',
+  'ch_interface.c',
+  'ch_interface.h',
 ]
 
 driver_source_files += files(ch_driver_sources)


### PR DESCRIPTION
Enable NAT network support similar to that in Qemu driver.
A new TAP interface is created and attached to configured bridge.

Signed-off-by: Praveen Paladugu <prapal@microsoft.com>