### PR TITLE
Implement automatic host devices management for CH driver

### DIFF
--- a/src/ch/ch_conf.h
+++ b/src/ch/ch_conf.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "virdomainobjlist.h"
+#include "virhostdev.h"
 #include "virthread.h"
 #include "virebtables.h"
 
@@ -80,6 +81,9 @@ struct _virCHDriver
 
     /* pid file FD, ensures two copies of the driver can't use the same root */
     int lockFD;
+
+    /* Immutable pointer to host device manager */
+    virHostdevManagerPtr hostdevMgr;
 };
 
 virCapsPtr virCHDriverCapsInit(void);

--- a/src/ch/ch_domain.h
+++ b/src/ch/ch_domain.h
@@ -25,6 +25,8 @@
 #include "virchrdev.h"
 #include "vircgroup.h"
 
+#define CH_DEV_VFIO "/dev/vfio/vfio"
+
 /* Give up waiting for mutex after 30 seconds */
 #define CH_JOB_WAIT_TIME (1000ull * 30)
 

--- a/src/ch/ch_driver.c
+++ b/src/ch/ch_driver.c
@@ -906,6 +906,7 @@ static int chStateCleanup(void)
     virObjectUnref(ch_driver->xmlopt);
     virObjectUnref(ch_driver->caps);
     virObjectUnref(ch_driver->config);
+    virObjectUnref(ch_driver->hostdevMgr);
     virMutexDestroy(&ch_driver->lock);
     VIR_FREE(ch_driver);
 
@@ -947,6 +948,9 @@ static int chStateInitialize(bool privileged,
         goto cleanup;
 
     if (!(ch_driver->config = virCHDriverConfigNew()))
+        goto cleanup;
+
+    if (!(ch_driver->hostdevMgr = virHostdevManagerGetDefault()))
         goto cleanup;
 
     if (chExtractVersion(ch_driver) < 0)

--- a/src/ch/ch_hostdev.c
+++ b/src/ch/ch_hostdev.c
@@ -1,0 +1,41 @@
+/*
+ * ch_hostdev.c: Cloud Hypervisor hostdev management
+ *
+ * Copyright (C) 2021 Wei Liu <liuwe@microsoft.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <config.h>
+
+#include <fcntl.h>
+#include <sys/ioctl.h>
+
+#include "ch_hostdev.h"
+#include "ch_domain.h"
+#include "virlog.h"
+#include "virerror.h"
+#include "viralloc.h"
+#include "virpci.h"
+#include "virusb.h"
+#include "virscsi.h"
+#include "virnetdev.h"
+#include "virfile.h"
+#include "virhostdev.h"
+#include "virutil.h"
+
+#define VIR_FROM_THIS VIR_FROM_CH
+
+VIR_LOG_INIT("ch.ch_hostdev");

--- a/src/ch/ch_hostdev.c
+++ b/src/ch/ch_hostdev.c
@@ -39,3 +39,320 @@
 #define VIR_FROM_THIS VIR_FROM_CH
 
 VIR_LOG_INIT("ch.ch_hostdev");
+
+bool
+chHostdevHostSupportsPassthroughVFIO(void)
+{
+    /* condition 1 - host has IOMMU */
+    if (!virHostHasIOMMU())
+        return false;
+
+    /* condition 2 - /dev/vfio/vfio exists */
+    if (!virFileExists(CH_DEV_VFIO))
+        return false;
+
+    return true;
+}
+
+bool
+chHostdevNeedsVFIO(const virDomainHostdevDef *hostdev)
+{
+    return virHostdevIsVFIODevice(hostdev) ||
+        virHostdevIsMdevDevice(hostdev);
+}
+
+static bool
+chHostdevPreparePCIDevicesCheckSupport(virDomainHostdevDefPtr *hostdevs,
+                                       size_t nhostdevs)
+{
+    bool supportsPassthroughVFIO = chHostdevHostSupportsPassthroughVFIO();
+    size_t i;
+
+    /* assign defaults for hostdev passthrough */
+    for (i = 0; i < nhostdevs; i++) {
+        virDomainHostdevDefPtr hostdev = hostdevs[i];
+        int *backend = &hostdev->source.subsys.u.pci.backend;
+
+        if (hostdev->mode != VIR_DOMAIN_HOSTDEV_MODE_SUBSYS)
+            continue;
+        if (hostdev->source.subsys.type != VIR_DOMAIN_HOSTDEV_SUBSYS_TYPE_PCI)
+            continue;
+
+        switch ((virDomainHostdevSubsysPCIBackendType)*backend) {
+        case VIR_DOMAIN_HOSTDEV_PCI_BACKEND_DEFAULT:
+            if (supportsPassthroughVFIO) {
+                *backend = VIR_DOMAIN_HOSTDEV_PCI_BACKEND_VFIO;
+            } else {
+                virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
+                               _("host doesn't support passthrough of "
+                                 "host PCI devices"));
+                return false;
+            }
+
+            break;
+
+        case VIR_DOMAIN_HOSTDEV_PCI_BACKEND_VFIO:
+            if (!supportsPassthroughVFIO) {
+                virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
+                               _("host doesn't support VFIO PCI passthrough"));
+                return false;
+            }
+            break;
+
+        case VIR_DOMAIN_HOSTDEV_PCI_BACKEND_KVM:
+        case VIR_DOMAIN_HOSTDEV_PCI_BACKEND_XEN:
+        case VIR_DOMAIN_HOSTDEV_PCI_BACKEND_TYPE_LAST:
+            virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s%s",
+                           _("host doesn't support passthrough: "),
+                           _(virDomainHostdevSubsysPCIBackendTypeToString(*backend)));
+            return false;
+        }
+    }
+
+    return true;
+}
+
+int
+chHostdevPrepareNVMeDisks(virCHDriverPtr driver,
+                          const char *name,
+                          virDomainDiskDefPtr *disks,
+                          size_t ndisks)
+{
+    return virHostdevPrepareNVMeDevices(driver->hostdevMgr,
+                                        CH_DRIVER_NAME,
+                                        name, disks, ndisks);
+}
+
+int
+chHostdevPreparePCIDevices(virCHDriverPtr driver,
+                           const char *name,
+                           const unsigned char *uuid,
+                           virDomainHostdevDefPtr *hostdevs,
+                           int nhostdevs,
+                           unsigned int flags)
+{
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+
+    if (!chHostdevPreparePCIDevicesCheckSupport(hostdevs, nhostdevs))
+        return -1;
+
+    return virHostdevPreparePCIDevices(hostdev_mgr, CH_DRIVER_NAME,
+                                       name, uuid, hostdevs,
+                                       nhostdevs, flags);
+}
+
+int
+chHostdevPrepareUSBDevices(virCHDriverPtr driver,
+                           const char *name,
+                           virDomainHostdevDefPtr *hostdevs,
+                           int nhostdevs,
+                           unsigned int flags)
+{
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+
+    return virHostdevPrepareUSBDevices(hostdev_mgr, CH_DRIVER_NAME, name,
+                                       hostdevs, nhostdevs, flags);
+}
+
+int
+chHostdevPrepareSCSIDevices(virCHDriverPtr driver,
+                            const char *name,
+                            virDomainHostdevDefPtr *hostdevs,
+                            int nhostdevs)
+{
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+
+    return virHostdevPrepareSCSIDevices(hostdev_mgr, CH_DRIVER_NAME,
+                                        name, hostdevs, nhostdevs);
+}
+
+int
+chHostdevPrepareSCSIVHostDevices(virCHDriverPtr driver,
+                                 const char *name,
+                                 virDomainHostdevDefPtr *hostdevs,
+                                 int nhostdevs)
+{
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+
+    return virHostdevPrepareSCSIVHostDevices(hostdev_mgr, CH_DRIVER_NAME,
+                                             name, hostdevs, nhostdevs);
+}
+
+int
+chHostdevPrepareMediatedDevices(virCHDriverPtr driver,
+                                const char *name,
+                                virDomainHostdevDefPtr *hostdevs,
+                                int nhostdevs)
+{
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+    bool supportsVFIO;
+    size_t i;
+
+    /* Checking for VFIO only is fine with mdev, as IOMMU isolation is achieved
+     * by the physical parent device.
+     */
+    supportsVFIO = virFileExists(CH_DEV_VFIO);
+
+    for (i = 0; i < nhostdevs; i++) {
+        if (virHostdevIsMdevDevice(hostdevs[i])) {
+            if (!supportsVFIO) {
+                virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
+                               _("Mediated host device assignment requires "
+                                 "VFIO support"));
+                return -1;
+            }
+            break;
+        }
+    }
+
+    return virHostdevPrepareMediatedDevices(hostdev_mgr, CH_DRIVER_NAME,
+                                            name, hostdevs, nhostdevs);
+}
+
+int
+chHostdevPrepareDomainDevices(virCHDriverPtr driver,
+                              virDomainDefPtr def,
+                              unsigned int flags)
+
+{
+    if (!def->nhostdevs && !def->ndisks)
+        return 0;
+
+    if (chHostdevPrepareNVMeDisks(driver, def->name, def->disks, def->ndisks) < 0)
+        return -1;
+
+    if (chHostdevPreparePCIDevices(driver, def->name, def->uuid,
+                                   def->hostdevs, def->nhostdevs,
+                                   flags) < 0)
+        return -1;
+
+    if (chHostdevPrepareUSBDevices(driver, def->name,
+                                   def->hostdevs, def->nhostdevs, flags) < 0)
+        return -1;
+
+    if (chHostdevPrepareSCSIDevices(driver, def->name,
+                                    def->hostdevs, def->nhostdevs) < 0)
+        return -1;
+
+    if (chHostdevPrepareSCSIVHostDevices(driver, def->name,
+                                         def->hostdevs, def->nhostdevs) < 0)
+        return -1;
+
+    if (chHostdevPrepareMediatedDevices(driver, def->name,
+                                        def->hostdevs, def->nhostdevs) < 0)
+        return -1;
+
+    return 0;
+}
+
+void
+chHostdevReAttachOneNVMeDisk(virCHDriverPtr driver,
+                             const char *name,
+                             virStorageSourcePtr src)
+{
+    virHostdevReAttachOneNVMeDevice(driver->hostdevMgr,
+                                    CH_DRIVER_NAME,
+                                    name,
+                                    src);
+}
+
+void
+chHostdevReAttachNVMeDisks(virCHDriverPtr driver,
+                           const char *name,
+                           virDomainDiskDefPtr *disks,
+                           size_t ndisks)
+{
+    virHostdevReAttachNVMeDevices(driver->hostdevMgr,
+                                  CH_DRIVER_NAME,
+                                  name, disks, ndisks);
+}
+
+void
+chHostdevReAttachPCIDevices(virCHDriverPtr driver,
+                            const char *name,
+                            virDomainHostdevDefPtr *hostdevs,
+                            int nhostdevs)
+{
+    virCHDriverConfigPtr cfg = virCHDriverGetConfig(driver);
+    const char *oldStateDir = cfg->stateDir;
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+
+    virHostdevReAttachPCIDevices(hostdev_mgr, CH_DRIVER_NAME, name,
+                                 hostdevs, nhostdevs, oldStateDir);
+
+    virObjectUnref(cfg);
+}
+
+void
+chHostdevReAttachUSBDevices(virCHDriverPtr driver,
+                            const char *name,
+                            virDomainHostdevDefPtr *hostdevs,
+                            int nhostdevs)
+{
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+
+    virHostdevReAttachUSBDevices(hostdev_mgr, CH_DRIVER_NAME,
+                                 name, hostdevs, nhostdevs);
+}
+
+void
+chHostdevReAttachSCSIDevices(virCHDriverPtr driver,
+                             const char *name,
+                             virDomainHostdevDefPtr *hostdevs,
+                             int nhostdevs)
+{
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+
+    virHostdevReAttachSCSIDevices(hostdev_mgr, CH_DRIVER_NAME,
+                                  name, hostdevs, nhostdevs);
+}
+
+void
+chHostdevReAttachSCSIVHostDevices(virCHDriverPtr driver,
+                                    const char *name,
+                                    virDomainHostdevDefPtr *hostdevs,
+                                    int nhostdevs)
+{
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+
+    virHostdevReAttachSCSIVHostDevices(hostdev_mgr, CH_DRIVER_NAME,
+                                       name, hostdevs, nhostdevs);
+}
+
+void
+chHostdevReAttachMediatedDevices(virCHDriverPtr driver,
+                                 const char *name,
+                                 virDomainHostdevDefPtr *hostdevs,
+                                 int nhostdevs)
+{
+    virHostdevManagerPtr hostdev_mgr = driver->hostdevMgr;
+
+    virHostdevReAttachMediatedDevices(hostdev_mgr, CH_DRIVER_NAME,
+                                      name, hostdevs, nhostdevs);
+}
+
+void
+chHostdevReAttachDomainDevices(virCHDriverPtr driver,
+                               virDomainDefPtr def)
+{
+    if (!def->nhostdevs && !def->ndisks)
+        return;
+
+    chHostdevReAttachNVMeDisks(driver, def->name, def->disks,
+                               def->ndisks);
+
+    chHostdevReAttachPCIDevices(driver, def->name, def->hostdevs,
+                                def->nhostdevs);
+
+    chHostdevReAttachUSBDevices(driver, def->name, def->hostdevs,
+                                def->nhostdevs);
+
+    chHostdevReAttachSCSIDevices(driver, def->name, def->hostdevs,
+                                 def->nhostdevs);
+
+    chHostdevReAttachSCSIVHostDevices(driver, def->name, def->hostdevs,
+                                      def->nhostdevs);
+
+    chHostdevReAttachMediatedDevices(driver, def->name, def->hostdevs,
+                                     def->nhostdevs);
+}

--- a/src/ch/ch_hostdev.h
+++ b/src/ch/ch_hostdev.h
@@ -22,3 +22,105 @@
 
 #include "ch_conf.h"
 #include "domain_conf.h"
+
+bool
+chHostdevHostSupportsPassthroughVFIO(void);
+
+bool
+chHostdevNeedsVFIO(const virDomainHostdevDef *hostdev);
+
+int
+chHostdevPrepareNVMeDisks(virCHDriverPtr driver,
+                          const char *name,
+                          virDomainDiskDefPtr *disks,
+                          size_t ndisks);
+
+int
+chHostdevPreparePCIDevices(virCHDriverPtr driver,
+                           const char *name,
+                           const unsigned char *uuid,
+                           virDomainHostdevDefPtr *hostdevs,
+                           int nhostdevs,
+                           unsigned int flags);
+
+int
+chHostdevPrepareUSBDevices(virCHDriverPtr driver,
+                           const char *name,
+                           virDomainHostdevDefPtr *hostdevs,
+                           int nhostdevs,
+                           unsigned int flags);
+
+
+int
+chHostdevPrepareUSBDevices(virCHDriverPtr driver,
+                           const char *name,
+                           virDomainHostdevDefPtr *hostdevs,
+                           int nhostdevs,
+                           unsigned int flags);
+
+int
+chHostdevPrepareSCSIDevices(virCHDriverPtr driver,
+                            const char *name,
+                            virDomainHostdevDefPtr *hostdevs,
+                            int nhostdevs);
+
+int
+chHostdevPrepareSCSIVHostDevices(virCHDriverPtr driver,
+                                 const char *name,
+                                 virDomainHostdevDefPtr *hostdevs,
+                                 int nhostdevs);
+
+int
+chHostdevPrepareMediatedDevices(virCHDriverPtr driver,
+                                const char *name,
+                                virDomainHostdevDefPtr *hostdevs,
+                                int nhostdevs);
+int
+chHostdevPrepareDomainDevices(virCHDriverPtr driver,
+                              virDomainDefPtr def,
+                              unsigned int flags);
+
+void
+chHostdevReAttachOneNVMeDisk(virCHDriverPtr driver,
+                             const char *name,
+                             virStorageSourcePtr src);
+
+void
+chHostdevReAttachNVMeDisks(virCHDriverPtr driver,
+                           const char *name,
+                           virDomainDiskDefPtr *disks,
+                           size_t ndisks);
+
+void
+chHostdevReAttachPCIDevices(virCHDriverPtr driver,
+                            const char *name,
+                            virDomainHostdevDefPtr *hostdevs,
+                            int nhostdevs);
+
+void
+chHostdevReAttachUSBDevices(virCHDriverPtr driver,
+                            const char *name,
+                            virDomainHostdevDefPtr *hostdevs,
+                            int nhostdevs);
+
+void
+chHostdevReAttachSCSIDevices(virCHDriverPtr driver,
+                             const char *name,
+                             virDomainHostdevDefPtr *hostdevs,
+                             int nhostdevs);
+
+void
+chHostdevReAttachSCSIVHostDevices(virCHDriverPtr driver,
+                                    const char *name,
+                                    virDomainHostdevDefPtr *hostdevs,
+                                    int nhostdevs);
+
+void
+chHostdevReAttachMediatedDevices(virCHDriverPtr driver,
+                                 const char *name,
+                                 virDomainHostdevDefPtr *hostdevs,
+                                 int nhostdevs);
+
+void
+chHostdevReAttachDomainDevices(virCHDriverPtr driver,
+                               virDomainDefPtr def);

--- a/src/ch/ch_hostdev.h
+++ b/src/ch/ch_hostdev.h
@@ -1,0 +1,24 @@
+/*
+ * ch_hostdev.h: Cloud Hypervisor hostdev management
+ *
+ * Copyright (C) 2021 Wei Liu <liuwe@microsoft.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "ch_conf.h"
+#include "domain_conf.h"

--- a/src/ch/ch_process.c
+++ b/src/ch/ch_process.c
@@ -29,6 +29,7 @@
 #include "ch_monitor.h"
 #include "ch_process.h"
 #include "ch_cgroup.h"
+#include "ch_hostdev.h"
 #include "virnuma.h"
 #include "viralloc.h"
 #include "virerror.h"
@@ -635,6 +636,11 @@ int virCHProcessStart(virCHDriverPtr driver,
     if (chProcessNetworkPrepareDevices(driver, vm) < 0)
         goto cleanup;
 
+    VIR_DEBUG("Preparing host devices");
+    if (chHostdevPrepareDomainDevices(driver, vm->def,
+                                      VIR_HOSTDEV_COLD_BOOT) < 0)
+        goto cleanup;
+
     if (!priv->monitor) {
         /* And we can get the first monitor connection now too */
         if (!(priv->monitor = virCHProcessConnectMonitor(driver, vm))) {
@@ -708,6 +714,8 @@ int virCHProcessStop(virCHDriverPtr driver G_GNUC_UNUSED,
         virCHMonitorClose(priv->monitor);
         priv->monitor = NULL;
     }
+
+    chHostdevReAttachDomainDevices(driver, vm->def);
 
 retry:
     if ((ret = chRemoveCgroup(vm)) < 0) {

--- a/src/ch/meson.build
+++ b/src/ch/meson.build
@@ -13,6 +13,8 @@ ch_driver_sources = [
   'ch_process.h',
   'ch_interface.c',
   'ch_interface.h',
+  'ch_hostdev.c',
+  'ch_hostdev.h',
 ]
 
 driver_source_files += files(ch_driver_sources)


### PR DESCRIPTION
At this stage we care about VFIO based devices only and that's the use case I tested. But I've implemented as many supported devices as possible.

This can be tested with the following snippet (replace those values with the ones from your own device):

```
    <hostdev mode='subsystem' type='pci' managed='yes'>
      <source>
        <address domain='0x0000'
                 bus='0x04'
                 slot='0x00'
                 function='0x0'/>
      </source>
    </hostdev>
```