### PR TITLE
Metadata persistance

### DIFF
--- a/src/ch/ch_domain.c
+++ b/src/ch/ch_domain.c
@@ -20,8 +20,8 @@
 
 #include <config.h>
 
-#include "datatypes.h"
 #include "ch_domain.h"
+#include "datatypes.h"
 #include "domain_driver.h"
 #include "viralloc.h"
 #include "virlog.h"

--- a/src/ch/ch_domain.h
+++ b/src/ch/ch_domain.h
@@ -44,19 +44,21 @@ enum virCHDomainJob {
 VIR_ENUM_DECL(virCHDomainJob);
 
 
-struct virCHDomainJobObj {
+struct _virCHDomainJobObj {
     virCond cond;                       /* Use to coordinate jobs */
     enum virCHDomainJob active;        /* Currently running job */
     int owner;                          /* Thread which set current job */
 };
 
+typedef struct _virCHDomainJobObj virCHDomainJobObj;
+typedef virCHDomainJobObj *virCHDomainJobObjPtr;
 
 typedef struct _virCHDomainObjPrivate virCHDomainObjPrivate;
 typedef virCHDomainObjPrivate *virCHDomainObjPrivatePtr;
 struct _virCHDomainObjPrivate {
     pid_t initpid;
 
-    struct virCHDomainJobObj job;
+    virCHDomainJobObj job;
 
     virCHDriverPtr driver;
 
@@ -65,6 +67,8 @@ struct _virCHDomainObjPrivate {
     virChrdevsPtr devs;
 
     char *machineName;
+
+    char *pidfile;
 
     virBitmapPtr autoNodeset;
     virBitmapPtr autoCpuset;
@@ -105,8 +109,26 @@ virCHDomainObjBeginJob(virDomainObjPtr obj, enum virCHDomainJob job)
 void
 virCHDomainObjEndJob(virDomainObjPtr obj);
 
+void
+virCHDomainRemoveInactive(virCHDriverPtr driver,
+                             virDomainObjPtr vm);
+
+void
+virCHDomainRemoveInactiveJob(virCHDriverPtr driver,
+                             virDomainObjPtr vm);
+
+void
+virCHDomainRemoveInactiveJobLocked(virCHDriverPtr driver,
+                                   virDomainObjPtr vm);
+
+int virCHDomainRefreshThreadInfo(virDomainObjPtr vm);
+
 pid_t virCHDomainGetVcpuPid(virDomainObjPtr vm, unsigned int vcpuid);
 bool virCHDomainHasVcpuPids(virDomainObjPtr vm);
 
 char *virCHDomainGetMachineName(virDomainObjPtr vm);
 virDomainObjPtr virCHDomainObjFromDomain(virDomainPtr domain);
+
+int
+virCHDomainObjRestoreJob(virDomainObjPtr obj,
+                         virCHDomainJobObjPtr job);

--- a/src/ch/ch_driver.c
+++ b/src/ch/ch_driver.c
@@ -956,6 +956,16 @@ static int chStateInitialize(bool privileged,
     if (chExtractVersion(ch_driver) < 0)
         goto cleanup;
 
+    /* Get all the running persistent or transient configs first */
+    if (virDomainObjListLoadAllConfigs(ch_driver->domains,
+                                       ch_driver->config->stateDir,
+                                       NULL, true,
+                                       ch_driver->xmlopt,
+                                       NULL, NULL) < 0)
+        goto cleanup;
+
+    chProcessReconnectAll(ch_driver);
+
     ch_driver->privileged = privileged;
 
     return VIR_DRV_STATE_INIT_COMPLETE;

--- a/src/ch/ch_hostdev.c
+++ b/src/ch/ch_hostdev.c
@@ -213,7 +213,6 @@ int
 chHostdevPrepareDomainDevices(virCHDriverPtr driver,
                               virDomainDefPtr def,
                               unsigned int flags)
-
 {
     if (!def->nhostdevs && !def->ndisks)
         return 0;
@@ -355,4 +354,93 @@ chHostdevReAttachDomainDevices(virCHDriverPtr driver,
 
     chHostdevReAttachMediatedDevices(driver, def->name, def->hostdevs,
                                      def->nhostdevs);
+}
+
+int
+chHostdevUpdateActivePCIDevices(virCHDriverPtr driver,
+                                virDomainDefPtr def)
+{
+    virHostdevManagerPtr mgr = driver->hostdevMgr;
+
+    if (!def->nhostdevs)
+        return 0;
+
+    return virHostdevUpdateActivePCIDevices(mgr, def->hostdevs, def->nhostdevs,
+                                            CH_DRIVER_NAME, def->name);
+}
+
+int
+chHostdevUpdateActiveUSBDevices(virCHDriverPtr driver,
+                                virDomainDefPtr def)
+{
+    virHostdevManagerPtr mgr = driver->hostdevMgr;
+
+    if (!def->nhostdevs)
+        return 0;
+
+    return virHostdevUpdateActiveUSBDevices(mgr, def->hostdevs, def->nhostdevs,
+                                            CH_DRIVER_NAME, def->name);
+}
+
+int
+chHostdevUpdateActiveSCSIDevices(virCHDriverPtr driver,
+                                 virDomainDefPtr def)
+{
+    virHostdevManagerPtr mgr = driver->hostdevMgr;
+
+    if (!def->nhostdevs)
+        return 0;
+
+    return virHostdevUpdateActiveSCSIDevices(mgr, def->hostdevs, def->nhostdevs,
+                                             CH_DRIVER_NAME, def->name);
+}
+
+int
+chHostdevUpdateActiveMediatedDevices(virCHDriverPtr driver,
+                                     virDomainDefPtr def)
+{
+    virHostdevManagerPtr mgr = driver->hostdevMgr;
+
+    if (!def->nhostdevs)
+        return 0;
+
+    return virHostdevUpdateActiveMediatedDevices(mgr, def->hostdevs,
+                                                 def->nhostdevs,
+                                                 CH_DRIVER_NAME, def->name);
+}
+
+int
+chHostdevUpdateActiveNVMeDisks(virCHDriverPtr driver,
+                               virDomainDefPtr def)
+{
+    return virHostdevUpdateActiveNVMeDevices(driver->hostdevMgr,
+                                             CH_DRIVER_NAME,
+                                             def->name,
+                                             def->disks,
+                                             def->ndisks);
+}
+
+int
+chHostdevUpdateActiveDomainDevices(virCHDriverPtr driver,
+                                   virDomainDefPtr def)
+{
+    if (!def->nhostdevs && !def->ndisks)
+        return 0;
+
+    if (chHostdevUpdateActiveNVMeDisks(driver, def) < 0)
+        return -1;
+
+    if (chHostdevUpdateActivePCIDevices(driver, def) < 0)
+        return -1;
+
+    if (chHostdevUpdateActiveUSBDevices(driver, def) < 0)
+        return -1;
+
+    if (chHostdevUpdateActiveSCSIDevices(driver, def) < 0)
+        return -1;
+
+    if (chHostdevUpdateActiveMediatedDevices(driver, def) < 0)
+        return -1;
+
+    return 0;
 }

--- a/src/ch/ch_hostdev.h
+++ b/src/ch/ch_hostdev.h
@@ -124,3 +124,27 @@ chHostdevReAttachMediatedDevices(virCHDriverPtr driver,
 void
 chHostdevReAttachDomainDevices(virCHDriverPtr driver,
                                virDomainDefPtr def);
+
+int
+chHostdevUpdateActivePCIDevices(virCHDriverPtr driver,
+                                virDomainDefPtr def)
+
+int
+chHostdevUpdateActiveUSBDevices(virCHDriverPtr driver,
+                                virDomainDefPtr def)
+
+int
+chHostdevUpdateActiveSCSIDevices(virCHDriverPtr driver,
+                                 virDomainDefPtr def)
+
+int
+chHostdevUpdateActiveMediatedDevices(virCHDriverPtr driver,
+                                     virDomainDefPtr def)
+
+int
+chHostdevUpdateActiveNVMeDisks(virCHDriverPtr driver,
+                               virDomainDefPtr def);
+
+int
+chHostdevUpdateActiveDomainDevices(virCHDriverPtr driver,
+                                   virDomainDefPtr def);

--- a/src/ch/ch_monitor.h
+++ b/src/ch/ch_monitor.h
@@ -103,7 +103,8 @@ struct _virCHMonitor {
     virCHMonitorThreadInfoPtr threads;
 };
 
-virCHMonitorPtr virCHMonitorNew(virDomainObjPtr vm, const char *socketdir);
+virCHMonitorPtr virCHMonitorOpen(virDomainObjPtr vm, virCHDriverPtr driver);
+virCHMonitorPtr virCHMonitorNew(virDomainObjPtr vm, virCHDriverPtr driver);
 void virCHMonitorClose(virCHMonitorPtr mon);
 
 int virCHMonitorCreateVM(virCHMonitorPtr mon,

--- a/src/ch/ch_process.h
+++ b/src/ch/ch_process.h
@@ -35,4 +35,8 @@ int virCHProcessSetupVcpu(virDomainObjPtr vm,
 int virCHProcessSetupIOThread(virDomainObjPtr vm,
                              virDomainIOThreadInfoPtr iothread);
 
-int virCHProcessSetupEmulatorThread(virDomainObjPtr vm, pid_t tid);
+int
+virCHProcessSetupEmulatorThread(virDomainObjPtr vm, pid_t tid);
+
+void
+chProcessReconnectAll(virCHDriverPtr driver);

--- a/src/ch/meson.build
+++ b/src/ch/meson.build
@@ -7,6 +7,8 @@ ch_driver_sources = [
   'ch_domain.h',
   'ch_driver.c',
   'ch_driver.h',
+  'ch_hostdev.c',
+  'ch_hostdev.h',
   'ch_monitor.c',
   'ch_monitor.h',
   'ch_process.c',


### PR DESCRIPTION
Fixes #33

Adds the initial code to handle persisting VM state to disk and parsing the state back out when libvirt starts up. There may be some potential issues to be addressed (killing libvirt in the middle of a shutdown, startup, etc) but the code is working for me as is for the common case of restoring the state of running vms.