### PR TITLE
ch: update monitor-fd option

### DIFF
--- a/src/ch/ch_monitor.c
+++ b/src/ch/ch_monitor.c
@@ -1048,8 +1048,8 @@ virCHMonitorNew(virDomainObjPtr vm, virCHDriverPtr driver)
         goto cleanup;
     }
     mon->monitor_fd = monitor_fds[0];
-    virCommandAddArg(cmd, "--monitor-fd");
-    virCommandAddArgFormat(cmd, "%d", monitor_fds[1]);
+    virCommandAddArg(cmd, "--event-monitor");
+    virCommandAddArgFormat(cmd, "fd=%d", monitor_fds[1]);
     virCommandPassFD(cmd, monitor_fds[1], VIR_COMMAND_PASS_FD_CLOSE_PARENT);
 
     /* TODO enable */


### PR DESCRIPTION
`monitor-fd` option is not longer supported in Cloud-Hypervisor, use
`event-monitor fd=` instead.

For more information about this change see
cloud-hypervisor commit b65502c3c1c9260a62f244070e2fc16dd19622df

fixes #49

Signed-off-by: Julio Montes <julio.montes@intel.com>