### PR TITLE
ch: Validate device type for serial/console

### DIFF
--- a/src/ch/ch_driver.c
+++ b/src/ch/ch_driver.c
@@ -865,7 +865,8 @@ chDomainOpenConsole(virDomainPtr dom,
                 chr = vm->def->parallels[i];
         }
     } else {
-        if (vm->def->nconsoles)
+        if (vm->def->nconsoles &&
+            vm->def->consoles[0]->source->type == VIR_DOMAIN_CHR_TYPE_PTY)
             chr = vm->def->consoles[0];
         else if (vm->def->nserials)
             chr = vm->def->serials[0];


### PR DESCRIPTION
When creating the vm configuration options passed to cloud-hypervisor,
look at the source->type and ensure it is a PTY before trying to use
that device.

Similarly when trying to open a console ensure the source->type is
also a PTY.

This is done as the vm->def for console may be populated with content
that isn't valid for cloud-hypervisor usage. The preferred vm
definition should contain the following:

```
<console type='pty'>
  <target type='serial' port='0'/>
</console>
```

for serial console and

```
<console type='pty'>
  <target type='virtio' port='0'/>
</console>
```

for virtio console (with only one defined regardless of type).