### PR TITLE
ch: Fix host IP assignment

### DIFF
--- a/src/ch/ch_monitor.c
+++ b/src/ch/ch_monitor.c
@@ -319,8 +319,8 @@ virCHMonitorBuildNetJson(virDomainObjPtr vm, virJSONValuePtr nets, virDomainNetD
 
     switch (netType) {
     case VIR_DOMAIN_NET_TYPE_ETHERNET:
-        if (netdef->guestIP.nips == 1) {
-            const virNetDevIPAddr *ip = netdef->guestIP.ips[0];
+        if (netdef->hostIP.nips == 1) {
+            const virNetDevIPAddr *ip = netdef->hostIP.ips[0];
             g_autofree char *addr = NULL;
             virSocketAddr netmask;
             g_autofree char *netmaskStr = NULL;


### PR DESCRIPTION
Cloud Hypervisor's network option "ip" refers to the host IP address a
user wants to set. The libvirt implementation should follow that by
retrieving IP addresses from hostIP structure instead of guestIP.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>