### PR TITLE
ch: Add support for 'setvcpus'

### DIFF
--- a/ch_integration_tests/run_tests.sh
+++ b/ch_integration_tests/run_tests.sh
@@ -13,8 +13,8 @@ if [ ! -f "$FW" ]; then
     popd
 fi
 
-FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210106-1.qcow2"
-FOCAL_OS_IMAGE_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$FOCAL_OS_IMAGE_NAME"
+FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64.img"
+FOCAL_OS_IMAGE_URL="https://cloud-images.ubuntu.com/focal/current/$FOCAL_OS_IMAGE_NAME"
 FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_IMAGE" ]; then
     pushd $WORKLOADS_DIR
@@ -22,7 +22,7 @@ if [ ! -f "$FOCAL_OS_IMAGE" ]; then
     popd
 fi
 
-FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210106-1.raw"
+FOCAL_OS_RAW_IMAGE_NAME="focal-server-cloudimg-amd64.raw"
 FOCAL_OS_RAW_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_RAW_IMAGE_NAME"
 if [ ! -f "$FOCAL_OS_RAW_IMAGE" ]; then
     pushd $WORKLOADS_DIR

--- a/ch_integration_tests/tests/integration.rs
+++ b/ch_integration_tests/tests/integration.rs
@@ -21,7 +21,7 @@ mod tests {
     use uuid::Uuid;
     use vmm_sys_util::tempdir::TempDir;
 
-    const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64-custom-20210106-1.raw";
+    const FOCAL_IMAGE_NAME: &str = "focal-server-cloudimg-amd64.raw";
 
     pub const DEFAULT_TCP_LISTENER_PORT: u16 = 8000;
     const DEFAULT_VCPUS: u8 = 1;
@@ -164,8 +164,10 @@ mod tests {
         }
 
         fn wait_vm_boot(&self, custom_timeout: Option<i32>) -> Result<(), Error> {
+            // Focal image requires more than default 80s to boot, that's why
+            // we set the default to 120s.
             self.network
-                .wait_vm_boot(custom_timeout)
+                .wait_vm_boot(custom_timeout.or(Some(120)))
                 .map_err(Error::WaitForBoot)
         }
 

--- a/src/ch/ch_driver.c
+++ b/src/ch/ch_driver.c
@@ -1899,6 +1899,12 @@ chDomainSetVcpusFlags(virDomainPtr dom,
     return ret;
 }
 
+static int
+chDomainSetVcpus(virDomainPtr dom, unsigned int nvcpus)
+{
+    return chDomainSetVcpusFlags(dom, nvcpus, VIR_DOMAIN_AFFECT_LIVE);
+}
+
 static int chDomainSetAutostart(virDomainPtr dom,
                                   int autostart)
 {
@@ -2045,7 +2051,7 @@ static virHypervisorDriver chHypervisorDriver = {
     .domainSetVcpusFlags = chDomainSetVcpusFlags,           /* 6.7.0 */
     .domainGetAutostart = chDomainGetAutostart,             /* 6.7.0 */
     .domainSetAutostart = chDomainSetAutostart,             /* 6.7.0 */
-
+    .domainSetVcpus = chDomainSetVcpus,                     /* 6.7.0 */
 };
 
 static virConnectDriver chConnectDriver = {


### PR DESCRIPTION
Add the missing bits to let libvirt know that 'setvcpus' command is supported by the ch driver. This enables vCPU hotplug for the ch driver.
The integration tests are extended to validate CPU hotplug is supported.