### PR TITLE
Jenkinsfile: Update Azure node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline{
 				}
 			}
 			stage ('Worker build') {
-				agent { node { label 'groovy' } }
+				agent { node { label 'groovy-libvirt' } }
 				stages {
 					stage ('Checkout') {
 						steps {


### PR DESCRIPTION
Change the Azure node name to 'groovy-libvirt', which is associated with
smaller groovy VMs (D4sv3 instead of D64s_v3).

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>