### PR TITLE
ch_integration_tests: Refactor XML creation

### DIFF
--- a/ch_integration_tests/Cargo.lock
+++ b/ch_integration_tests/Cargo.lock
@@ -77,6 +77,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "regex",
+ "simple_xml_serialize",
  "ssh2",
  "test_infra",
  "uuid",
@@ -309,6 +310,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "simple_xml_serialize"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d8a1704925a4f089a24d21dfd491ce8ba91dc93024023e48270f854560ea13"
 
 [[package]]
 name = "smallvec"

--- a/ch_integration_tests/Cargo.toml
+++ b/ch_integration_tests/Cargo.toml
@@ -11,6 +11,7 @@ epoll = "4.3.1"
 libc = ">=0.2.91"
 lazy_static= "1.4.0"
 regex = "1.4.5"
+simple_xml_serialize = "0.1.0"
 ssh2 = "0.9.1"
 test_infra = { git = "https://github.com/cloud-hypervisor/cloud-hypervisor" }
 uuid = { version = "0.8", features = ["v4"] }


### PR DESCRIPTION
Rely on an external crate to generate dynamically libvirt domain XML.
This anticipates the need to opt in or out some parameters, which is not
possible with static XML generation.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>