### PR TITLE
ch_integration_tests: Add OVMF firmware booting test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,16 @@ pipeline{
 							checkout scm
 						}
 					}
+					stage ('Download assets') {
+						steps {
+							sh "mkdir -p ${env.HOME}/workloads"
+							azureDownload(storageCredentialId: 'ch-image-store',
+										  containerName: 'private-images',
+										  includeFilesPattern: 'OVMF-4b47d0c6c8.fd',
+										  downloadType: 'container',
+										  downloadDirLoc: "${env.HOME}/workloads")
+						}
+					}
 					stage ('Install dependencies') {
 						steps {
 							sh "sudo apt update && sudo apt install -y meson ninja-build gcc libxml2-utils xsltproc python3-docutils libglib2.0-dev libgnutls28-dev libxml2-dev libnl-3-dev libnl-route-3-dev libyajl-dev make libcurl4-gnutls-dev qemu-utils libssl-dev mtools libudev-dev libpciaccess-dev flex bison libelf-dev"

--- a/ch_integration_tests/run_tests.sh
+++ b/ch_integration_tests/run_tests.sh
@@ -13,6 +13,13 @@ if [ ! -f "$FW" ]; then
     popd
 fi
 
+OVMF_FW="$WORKLOADS_DIR/OVMF-4b47d0c6c8.fd"
+# Check OVMF firmware is present
+if [[ ! -f ${OVMF_FW} ]]; then
+    echo "OVMF firmware not present on the host"
+    exit 1
+fi
+
 FOCAL_OS_IMAGE_NAME="focal-server-cloudimg-amd64-custom-20210407-0.qcow2"
 FOCAL_OS_IMAGE_URL="https://cloudhypervisorstorage.blob.core.windows.net/images/$FOCAL_OS_IMAGE_NAME"
 FOCAL_OS_IMAGE="$WORKLOADS_DIR/$FOCAL_OS_IMAGE_NAME"

--- a/ch_integration_tests/tests/integration.rs
+++ b/ch_integration_tests/tests/integration.rs
@@ -57,26 +57,30 @@ mod tests {
     #[derive(PartialEq)]
     enum KernelType {
         Direct,
+        OvmfFw,
         RustFw,
     }
 
     impl KernelType {
         fn path(&self) -> PathBuf {
+            #[cfg(target_arch = "aarch64")]
+            assert!(self == KernelType::Direct);
+
             let mut kernel_path = dirs::home_dir().unwrap();
             kernel_path.push("workloads");
 
             match self {
-                KernelType::RustFw => {
-                    #[cfg(target_arch = "aarch64")]
-                    kernel_path.push("Image");
-                    #[cfg(target_arch = "x86_64")]
-                    kernel_path.push("hypervisor-fw");
-                }
                 KernelType::Direct => {
                     #[cfg(target_arch = "aarch64")]
                     kernel_path.push("Image");
                     #[cfg(target_arch = "x86_64")]
                     kernel_path.push("vmlinux");
+                }
+                KernelType::OvmfFw => {
+                    kernel_path.push("OVMF-4b47d0c6c8.fd");
+                }
+                KernelType::RustFw => {
+                    kernel_path.push("hypervisor-fw");
                 }
             }
 
@@ -572,6 +576,11 @@ mod tests {
         );
 
         assert!(r.is_ok());
+    }
+
+    #[test]
+    fn test_ovmf_fw_boot() {
+        test_create_vm(KernelType::OvmfFw)
     }
 
     #[test]


### PR DESCRIPTION
Add a new integration test to validate that libvirt can boot a Cloud
Hypervisor VM using the OVMF firmware.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>