### PR TITLE
ch: Update version string format parsing

### DIFF
--- a/src/ch/ch_conf.c
+++ b/src/ch/ch_conf.c
@@ -195,7 +195,7 @@ chExtractVersionInfo(int *retversion)
     if ((tmp = STRSKIP(tmp, "cloud-hypervisor v")) == NULL)
         goto cleanup;
 
-    if (virParseVersionString(tmp, &version, false) < 0)
+    if (virParseVersionString(tmp, &version, true) < 0)
         goto cleanup;
 
     // v0.9.0 is the minimum supported version


### PR DESCRIPTION
The micro portion of the version string has been removed from
`cloud-hypervisor --version` so has the version parser ignore missing
portions of the version number.