### PR TITLE
ch: enable bridge mode networking

### DIFF
--- a/src/ch/ch_monitor.c
+++ b/src/ch/ch_monitor.c
@@ -371,6 +371,7 @@ virCHMonitorBuildNetJson(virDomainObjPtr vm, virJSONValuePtr nets, virDomainNetD
         //nothing more to do here
         break;
     case VIR_DOMAIN_NET_TYPE_BRIDGE:
+        break;
     case VIR_DOMAIN_NET_TYPE_DIRECT:
     case VIR_DOMAIN_NET_TYPE_USER:
     case VIR_DOMAIN_NET_TYPE_SERVER:

--- a/src/ch/ch_process.c
+++ b/src/ch/ch_process.c
@@ -589,7 +589,7 @@ chProcessNetworkPrepareDevices(virCHDriverPtr driver, virDomainObjPtr vm)
         } else if (actualType == VIR_DOMAIN_NET_TYPE_USER ) {
             virReportError(VIR_ERR_INTERNAL_ERROR,
               _("VIR_DOMAIN_NET_TYPE_USER is not a supported Network type"));
-        } else if (actualType == VIR_DOMAIN_NET_TYPE_NETWORK) {
+        } else if (actualType == VIR_DOMAIN_NET_TYPE_NETWORK || actualType == VIR_DOMAIN_NET_TYPE_BRIDGE ) {
             tapfdSize = net->driver.virtio.queues;
             if (!tapfdSize)
                 tapfdSize = 1;


### PR DESCRIPTION
with this change I can get Bridge mode networking working with the following interface configurations:

```
<interface type='bridge'>
    <mac address='52:54:00:71:b1:b6'/>
    <source bridge='mybr0'/>
    <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
</interface>

....

<interface type='bridge'>
    <mac address='52:54:00:71:b1:b6'/>
    <source bridge='ovsbr0'/>
    <virtualport type='openvswitch'/>
    <address type='pci' domain='0x0000' bus='0x00' slot='0x03' function='0x0'/>
</interface>

```