### PR TITLE
Refactor network support CH driver

### DIFF
--- a/src/ch/ch_conf.c
+++ b/src/ch/ch_conf.c
@@ -171,7 +171,7 @@ virCHDriverConfigDispose(void *obj)
     g_free(cfg->logDir);
 }
 
-int
+static int
 virCHVersionString(const char *str, unsigned long *version)
 {
     unsigned int major, minor = 0, micro = 0;
@@ -179,15 +179,15 @@ virCHVersionString(const char *str, unsigned long *version)
     /**
      * Remove the from "cloud-hypervisor " to last "/" if present any from version output
      * Below snippet will give something line v<>.<>.(any dirty data if any)
-     * 
+     *
      * upstream CLH release version : cloud-hypervisor v32.0.0
      * upstream CLH main branch build : cloud-hypervisor v33.0-104-ge0e3779e-dirty
      * msft CLH main branch build : cloud-hypervisor msft/v32.0.131-1-ga5d6db5c-dirty
     */
-    char *clh_string = "cloud-hypervisor ";
-    char *last_slash = strrchr(str, '/');
-    char *clh_string_start = strstr(str, clh_string);
-    char *version_string = "";
+    const char *clh_string = "cloud-hypervisor ";
+    const char *last_slash = strrchr(str, '/');
+    const char *clh_string_start = strstr(str, clh_string);
+    const char *version_string = "";
 
     if (clh_string_start == NULL){
         VIR_ERROR("No matching format found: %s\n", str);

--- a/src/ch/ch_interface.c
+++ b/src/ch/ch_interface.c
@@ -146,7 +146,7 @@ chInterfaceEthernetConnect(virDomainDefPtr def,
  * @def: the definition of the VM
  * @driver: qemu driver data
  * @net: pointer to the VM's interface description
- * @tapfd: array of file descriptor return value for the new device
+ * @tapfds: array of file descriptors returned for the new device
  * @tapfdsize: number of file descriptors in @tapfd
  *
  * Called *only* called if actualType is VIR_DOMAIN_NET_TYPE_NETWORK or
@@ -154,11 +154,10 @@ chInterfaceEthernetConnect(virDomainDefPtr def,
  * device connecting to a bridge device)
  */
 int
-chInterfaceBridgeConnect(virDomainDefPtr def,
-                           virCHDriverPtr driver,
-                           virDomainNetDefPtr net,
-                           int *tapfd,
-                           size_t *tapfdSize)
+chInterfaceBridgeConnect(virDomainDef *def,
+                           virCHDriver *driver,
+                           virDomainNetDef *net,
+                           int *tapfds)
 {
     const char *brname;
     int ret = 0;
@@ -195,7 +194,7 @@ chInterfaceBridgeConnect(virDomainDefPtr def,
 
     if (driver->privileged) {
         if (virNetDevTapCreateInBridgePort(brname, &net->ifname, &net->mac,
-                                           def->uuid, tunpath, tapfd, *tapfdSize,
+                                           def->uuid, tunpath, tapfds, net->driver.virtio.queues,
                                            virDomainNetGetActualVirtPortProfile(net),
                                            virDomainNetGetActualVlan(net),
                                            virDomainNetGetActualPortOptionsIsolated(net),
@@ -245,8 +244,8 @@ chInterfaceBridgeConnect(virDomainDefPtr def,
  cleanup:
     if (ret < 0) {
         size_t i;
-        for (i = 0; i < *tapfdSize && tapfd[i] >= 0; i++)
-            VIR_FORCE_CLOSE(tapfd[i]);
+        for (i = 0; i < net->driver.virtio.queues && tapfds[i] >= 0; i++)
+            VIR_FORCE_CLOSE(tapfds[i]);
         if (template_ifname)
             g_free(net->ifname);
     }

--- a/src/ch/ch_interface.h
+++ b/src/ch/ch_interface.h
@@ -8,10 +8,9 @@ chInterfaceEthernetConnect(virDomainDefPtr def,
                            int *tapfd,
                            size_t tapfdSize);
 
-int chInterfaceBridgeConnect(virDomainDefPtr def,
-                           virCHDriverPtr driver,
-                           virDomainNetDefPtr net,
-                           int *tapfd,
-                           size_t *tapfdSize);
+int chInterfaceBridgeConnect(virDomainDef *def,
+                           virCHDriver *driver,
+                           virDomainNetDef *net,
+                           int *tapfd);
 
 int chInterfaceStartDevices(virDomainDefPtr def);

--- a/src/ch/ch_monitor.c
+++ b/src/ch/ch_monitor.c
@@ -29,6 +29,7 @@
 
 #include <curl/curl.h>
 
+#include "datatypes.h"
 #include "ch_conf.h"
 #include "ch_domain.h"
 #include "ch_monitor.h"
@@ -339,6 +340,113 @@ virCHMonitorBuildResizeCPUsJson(virJSONValuePtr content, unsigned int nvcpus)
 
     return 0;
 }
+
+/* Build and return net json & FDs to send to CH */
+int
+virCHMonitorBuildNetJson(virDomainObj *vm, virCHDriver *driver,
+                        virDomainNetDef *netdef, char **jsonstr, int *fds)
+{
+    virDomainNetType actualType = virDomainNetGetActualType(netdef);
+    virDomainDef *vmdef = vm->def;
+    char macaddr[VIR_MAC_STRING_BUFLEN];
+    g_autoptr(virJSONValue) net = virJSONValueNewObject();
+    g_autoptr(virConnect) conn = NULL;
+
+    switch (actualType) {
+    case VIR_DOMAIN_NET_TYPE_ETHERNET:
+        if (chInterfaceEthernetConnect(vmdef, driver, netdef,
+                                        fds, netdef->driver.virtio.queues) < 0)
+                return -1;
+
+        if (netdef->guestIP.nips == 1) {
+            const virNetDevIPAddr *ip = netdef->guestIP.ips[0];
+            g_autofree char *addr = NULL;
+            virSocketAddr netmask;
+            g_autofree char *netmaskStr = NULL;
+
+            if (!(addr = virSocketAddrFormat(&ip->address)))
+                return -1;
+            if (virJSONValueObjectAppendString(net, "ip", addr) < 0)
+                return -1;
+
+            if (virSocketAddrPrefixToNetmask(ip->prefix, &netmask, AF_INET) < 0) {
+                virReportError(VIR_ERR_INTERNAL_ERROR,
+                            _("Failed to translate net prefix %1$d to netmask"),
+                            ip->prefix);
+                return -1;
+            }
+            if (!(netmaskStr = virSocketAddrFormat(&netmask)))
+                return -1;
+
+            if (virJSONValueObjectAppendString(net, "mask", netmaskStr) < 0)
+                return -1;
+
+        } else if (netdef->guestIP.nips > 1) {
+            virReportError(VIR_ERR_CONFIG_UNSUPPORTED, "%s",
+                            _("ethernet type supports a single guest ip"));
+        }
+
+        break;
+    case VIR_DOMAIN_NET_TYPE_VHOSTUSER:
+    case VIR_DOMAIN_NET_TYPE_NETWORK:
+    case VIR_DOMAIN_NET_TYPE_BRIDGE:
+    case VIR_DOMAIN_NET_TYPE_DIRECT:
+    case VIR_DOMAIN_NET_TYPE_USER:
+    case VIR_DOMAIN_NET_TYPE_SERVER:
+    case VIR_DOMAIN_NET_TYPE_CLIENT:
+    case VIR_DOMAIN_NET_TYPE_MCAST:
+    case VIR_DOMAIN_NET_TYPE_INTERNAL:
+    case VIR_DOMAIN_NET_TYPE_HOSTDEV:
+    case VIR_DOMAIN_NET_TYPE_UDP:
+    case VIR_DOMAIN_NET_TYPE_LAST:
+    default:
+        virReportError(VIR_ERR_CONFIG_UNSUPPORTED,
+                       _("Unsupported Network type %d"), actualType);
+        return -1;
+    }
+    if (virJSONValueObjectAppendString(net, "mac",
+                            virMacAddrFormat(&netdef->mac, macaddr)) < 0)
+        return -1;
+
+    if (netdef->virtio != NULL) {
+        if (netdef->virtio->iommu == VIR_TRISTATE_SWITCH_ON) {
+            if (virJSONValueObjectAppendBoolean(net, "iommu", true) < 0)
+                return -1;
+        }
+    }
+
+    // Cloud-Hypervisor expects number of queues. 1 for rx and 1 for tx.
+    // Multiply QeueuPairs with 2 to provide total number of queues to CH
+    if (netdef->driver.virtio.queues) {
+        if (virJSONValueObjectAppendNumberInt(net, "num_queues",
+                                    2 * netdef->driver.virtio.queues) < 0)
+            return -1;
+    }
+
+    if (netdef->driver.virtio.rx_queue_size || netdef->driver.virtio.tx_queue_size) {
+        if (netdef->driver.virtio.rx_queue_size != netdef->driver.virtio.tx_queue_size) {
+            virReportError(VIR_ERR_CONFIG_UNSUPPORTED,
+               _("virtio rx_queue_size option %1$d is not same with tx_queue_size %2$d"),
+               netdef->driver.virtio.rx_queue_size,
+               netdef->driver.virtio.tx_queue_size);
+            return -1;
+        }
+        if (virJSONValueObjectAppendNumberInt(net, "queue_size",
+                                    netdef->driver.virtio.rx_queue_size) < 0)
+            return -1;
+    }
+
+    if (netdef->mtu) {
+        if (virJSONValueObjectAppendNumberInt(net, "mtu", netdef->mtu) < 0)
+            return -1;
+    }
+
+    if (!(*jsonstr = virJSONValueToString(net, false)))
+        return -1;
+
+    return 0;
+}
+
 
 static int
 virCHMonitorBuildVMJson(virDomainDefPtr vmdef, char **jsonstr)

--- a/src/ch/ch_monitor.c
+++ b/src/ch/ch_monitor.c
@@ -395,8 +395,17 @@ virCHMonitorBuildNetJson(virDomainObj *vm, virCHDriver *driver,
             }
         }
         break;
-    case VIR_DOMAIN_NET_TYPE_VHOSTUSER:
     case VIR_DOMAIN_NET_TYPE_NETWORK:
+        if (!conn && !(conn = virGetConnectNetwork()))
+                return -1;
+
+        if (virDomainNetAllocateActualDevice(conn, vmdef, netdef) < 0)
+                return -1;
+
+        if (chInterfaceBridgeConnect(vmdef, driver,  netdef, fds) < 0)
+            return -1;
+        break;
+    case VIR_DOMAIN_NET_TYPE_VHOSTUSER:
     case VIR_DOMAIN_NET_TYPE_BRIDGE:
     case VIR_DOMAIN_NET_TYPE_DIRECT:
     case VIR_DOMAIN_NET_TYPE_USER:

--- a/src/ch/ch_monitor.h
+++ b/src/ch/ch_monitor.h
@@ -178,3 +178,8 @@ int virCHMonitorGetInfo(virCHMonitorPtr mon, virJSONValuePtr *info);
 int
 virCHMonitorResizeCPU(virCHMonitorPtr mon,
                       unsigned int nvcpus);
+
+int
+virCHMonitorBuildNetJson(virDomainObj *vm, virCHDriver *driver,
+                        virDomainNetDef *netdef, char **jsonstr, int *fds);
+

--- a/src/ch/ch_monitor.h
+++ b/src/ch/ch_monitor.h
@@ -181,5 +181,5 @@ virCHMonitorResizeCPU(virCHMonitorPtr mon,
 
 int
 virCHMonitorBuildNetJson(virDomainObj *vm, virCHDriver *driver,
-                        virDomainNetDef *netdef, char **jsonstr, int *fds);
-
+                        virDomainNetDef *netdef, char **jsonstr, int *fds,
+                        size_t *nnicindexes, int **nicindexes);

--- a/src/ch/ch_monitor.h
+++ b/src/ch/ch_monitor.h
@@ -159,8 +159,7 @@ virCHMonitorPtr virCHMonitorOpen(virDomainObjPtr vm, virCHDriverPtr driver);
 virCHMonitorPtr virCHMonitorNew(virDomainObjPtr vm, virCHDriverPtr driver);
 void virCHMonitorClose(virCHMonitorPtr mon);
 
-int virCHMonitorCreateVM(virCHMonitorPtr mon,
-                         size_t *nnicindexes, int **nicindexes);
+int virCHMonitorCreateVM(virCHMonitorPtr mon);
 int virCHMonitorBootVM(virCHMonitorPtr mon);
 int virCHMonitorShutdownVM(virCHMonitorPtr mon);
 int virCHMonitorRebootVM(virCHMonitorPtr mon);

--- a/src/ch/ch_process.c
+++ b/src/ch/ch_process.c
@@ -38,6 +38,8 @@
 #include "virjson.h"
 #include "virlog.h"
 #include "virpidfile.h"
+#include "virstring.h"
+#include "virsocket.h"
 
 #define VIR_FROM_THIS VIR_FROM_CH
 
@@ -531,6 +533,107 @@ int virCHProcessSetupThreads(virDomainObjPtr vm)
     return ret;
 }
 
+static int
+chProcessAddNetworkDevices(virDomainObj *vm, virCHDriver *driver,
+                            virCHMonitor *mon, virDomainDef *vmdef) {
+
+    int i, j, fd_len, mon_sockfd, http_res;
+    int *fds = NULL;
+    g_autoptr(virJSONValue) net = NULL;
+    g_autofree char *payload = NULL;
+
+    struct sockaddr_un server_addr;
+    g_auto(virBuffer) buf = VIR_BUFFER_INITIALIZER;
+    g_auto(virBuffer) http_headers = VIR_BUFFER_INITIALIZER;
+    int ret;
+
+    mon_sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (mon_sockfd < 0) {
+        virReportSystemError(errno, "%s", _("Unable to open UNIX socket"));
+        return -1;
+    }
+
+    memset(&server_addr, 0, sizeof(server_addr));
+    server_addr.sun_family = AF_UNIX;
+    if (virStrcpyStatic(server_addr.sun_path, mon->socketpath) < 0) {
+        virReportError(VIR_ERR_INTERNAL_ERROR,
+                       _("UNIX socket path '%1$s' too long"),
+                       mon->socketpath);
+        return -1;
+    }
+
+    if (connect(mon_sockfd, (struct sockaddr *)&server_addr,
+                    sizeof(server_addr)) == -1) {
+        perror("connect");
+        close(mon_sockfd);
+        return -1;
+    }
+
+    // Append HTTP headers for AddNet API request
+    virBufferAsprintf(&http_headers, "PUT /api/v1/vm.add-net HTTP/1.1\r\n");
+    virBufferAsprintf(&http_headers, "Host: localhost\r\n");
+    virBufferAsprintf(&http_headers, "Content-Type: application/json\r\n");
+
+    for (i = 0; i < vmdef->nnets; i++) {
+        fd_len = vm->def->nets[i]->driver.virtio.queues;
+        if (!fd_len) {
+            /* "queues" here refers to Queue Pairs. When zero, initialize
+             * queue pairs to 1.
+             */
+            fd_len = vm->def->nets[i]->driver.virtio.queues = 1;
+        }
+
+        fds = malloc(sizeof(int)*fd_len);
+        memset(fds, -1, fd_len * sizeof(int));
+        if (virCHMonitorBuildNetJson(vm, driver, vm->def->nets[i],
+                                    &payload, fds) < 0) {
+            virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
+                           _("Failed to build net json"));
+            free(fds);
+            goto err;
+        }
+
+        virBufferAsprintf(&buf, "%s", virBufferCurrentContent(&http_headers));
+        virBufferAsprintf(&buf, "Content-Length: %ld\r\n\r\n",strlen(payload));
+        virBufferAsprintf(&buf,"%s",payload);
+
+        payload = virBufferContentAndReset(&buf);
+
+        ret = virSocketSendMsgWithFD(mon_sockfd, payload, fds, fd_len);
+        if (ret < 0) {
+            virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
+                           _("Failed to Send Network FDs to CH"));
+            free(fds);
+            goto err;
+        }
+
+        // Close sent Tap FDs in Libvirt
+        for (j=0; j<fd_len; j++) {
+            close(fds[j]);
+        }
+        free(fds);
+
+        // Process the response from CH
+        http_res = virSocketRecvHttpResponse(mon_sockfd);
+        if (http_res < 0) {
+            VIR_ERROR("Failed while receiving response from CH");
+            goto err;
+        }
+        if (http_res!=204 && http_res!=200) {
+            VIR_ERROR("Unexpected response from CH");
+            goto err;
+        }
+    }
+
+    close(mon_sockfd);
+    return 0;
+
+err:
+    close(mon_sockfd);
+    return -1;
+}
+
+
 /**
  * virCHProcessStart:
  * @driver: pointer to driver structure
@@ -579,6 +682,19 @@ int virCHProcessStart(virCHDriverPtr driver,
 
     if (virCHProcessInitCpuAffinity(vm) < 0)
         goto cleanup;
+
+    /* Send NIC FDs with AddNet API. Do this after VM Creation but before
+     * booting up the Guest
+     */
+    if (chProcessAddNetworkDevices(vm, driver, priv->monitor, vm->def) <0 ) {
+        virReportError(VIR_ERR_INTERNAL_ERROR, "%s",
+                       _("Failed while setting up Guest Network"));
+        goto cleanup;
+    }
+
+    /* Bring up netdevs before starting CPUs */
+    if (chInterfaceStartDevices(vm->def) < 0)
+       return -1;
 
     if (virCHMonitorBootVM(priv->monitor) < 0) {
         virReportError(VIR_ERR_INTERNAL_ERROR, "%s",

--- a/src/internal.h
+++ b/src/internal.h
@@ -145,13 +145,12 @@
  *
  * TODO: Remove after upgrading to GLib >= 2.60
  */
-#ifndef G_GNUC_FALLTHROUGH
+#undef G_GNUC_FALLTHROUGH
 # if __GNUC_PREREQ (7, 0)
 #  define G_GNUC_FALLTHROUGH __attribute__((fallthrough))
 # else
 #  define G_GNUC_FALLTHROUGH do {} while(0)
 # endif
-#endif
 
 #define VIR_WARNINGS_NO_CAST_ALIGN \
     _Pragma ("GCC diagnostic push") \

--- a/src/libvirt_private.syms
+++ b/src/libvirt_private.syms
@@ -3063,6 +3063,8 @@ virSecretLookupParseSecret;
 # util/virsocket.h
 virSocketRecvFD;
 virSocketSendFD;
+virSocketSendMsgWithFD;
+virSocketRecvHttpResponse;
 
 
 # util/virsocketaddr.h

--- a/src/util/virsocket.h
+++ b/src/util/virsocket.h
@@ -22,6 +22,9 @@
 
 int virSocketSendFD(int sock, int fd);
 int virSocketRecvFD(int sock, int fdflags);
+int virSocketSendMsgWithFD(int sock, const char *payload, int *fds,
+                            size_t fd_len);
+int virSocketRecvHttpResponse(int sock);
 
 #ifdef WIN32
 

--- a/tests/pkix_asn1_tab.c
+++ b/tests/pkix_asn1_tab.c
@@ -5,7 +5,7 @@
 #include <config.h>
 #include <libtasn1.h>
 
-const ASN1_ARRAY_TYPE pkix_asn1_tab[] = {
+const asn1_static_node pkix_asn1_tab[] = {
   { "PKIX1", 536875024, NULL },
   { NULL, 1073741836, NULL },
   { "id-pkix", 1879048204, NULL },

--- a/tests/virnettlshelpers.c
+++ b/tests/virnettlshelpers.c
@@ -37,8 +37,8 @@ VIR_LOG_INIT("tests.nettlshelpers");
  * These store some static data that is needed when
  * encoding extensions in the x509 certs
  */
-ASN1_TYPE pkix_asn1;
-extern const ASN1_ARRAY_TYPE pkix_asn1_tab[];
+asn1_node pkix_asn1;
+extern const asn1_static_node pkix_asn1_tab[];
 
 /*
  * To avoid consuming random entropy to generate keys,
@@ -107,7 +107,7 @@ void testTLSCleanup(const char *keyfile)
 /*
  * Turns an ASN1 object into a DER encoded byte array
  */
-static void testTLSDerEncode(ASN1_TYPE src,
+static void testTLSDerEncode(asn1_node src,
                              const char *src_name,
                              gnutls_datum_t * res)
 {
@@ -268,7 +268,7 @@ testTLSGenerateCert(struct testTLSCertReq *req,
      * the 'critical' field which we want control over
      */
     if (req->basicConstraintsEnable) {
-        ASN1_TYPE ext = ASN1_TYPE_EMPTY;
+        asn1_node ext = NULL;
 
         asn1_create_element(pkix_asn1, "PKIX1.BasicConstraints", &ext);
         asn1_write_value(ext, "cA", req->basicConstraintsIsCA ? "TRUE" : "FALSE", 1);
@@ -293,7 +293,7 @@ testTLSGenerateCert(struct testTLSCertReq *req,
      * to be 'critical'
      */
     if (req->keyUsageEnable) {
-        ASN1_TYPE ext = ASN1_TYPE_EMPTY;
+        asn1_node ext = NULL;
         char str[2];
 
         str[0] = req->keyUsageValue & 0xff;
@@ -322,7 +322,7 @@ testTLSGenerateCert(struct testTLSCertReq *req,
      * set this the hard way building up ASN1 data ourselves
      */
     if (req->keyPurposeEnable) {
-        ASN1_TYPE ext = ASN1_TYPE_EMPTY;
+        asn1_node ext = NULL;
 
         asn1_create_element(pkix_asn1, "PKIX1.ExtKeyUsageSyntax", &ext);
         if (req->keyPurposeOID1) {


### PR DESCRIPTION
This PR adds support to pass tap FDs to Cloud-Hypervisor using `SCM_RIGHTS`. The previous version passed the tap FD to cloud-hypervisor(ch) process at the time of process creation. This series cleans up the previous implementation and adds support for `NET_TYPE_NETWORK` and `NET_TYPE_ETHERNET` network modes.

I also fixed a few build time compile warnings.