### PR TITLE
Fix page.xsl Qname invalid error

### DIFF
--- a/docs/page.xsl
+++ b/docs/page.xsl
@@ -202,11 +202,11 @@
     </xsl:element>
   </xsl:template>
 
-  <xsl:template match="text()" mode="copy">
+  <xsl:template match="text()" mode="copy" priority="0">
     <xsl:value-of select="."/>
   </xsl:template>
 
-  <xsl:template match="node()" mode="copy">
+  <xsl:template match="*" mode="copy">
     <xsl:element name="{name()}">
       <xsl:copy-of select="./@*"/>
       <xsl:apply-templates mode="copy" />


### PR DESCRIPTION
Fix the xsl file for below error

xsl:element: The effective name '' is not a valid QName.
runtime error: file ../docs/page.xsl line 210 element element

Refer: https://lore.kernel.org/all/20220310025642.35956-1-kai.kang@windriver.com/T/