### PR TITLE
ch: increase MONITOR_TMP_FAIL_RETRIES to 50

### DIFF
--- a/src/ch/ch_monitor.c
+++ b/src/ch/ch_monitor.c
@@ -50,7 +50,8 @@
  * Retry count for temporary failures observed
  * in Monitor code path.
  */
-#define MONITOR_TMP_FAIL_RETRIES 5
+#define MONITOR_TMP_FAIL_RETRIES 50
+
 
 VIR_LOG_INIT("ch.ch_monitor");
 


### PR DESCRIPTION
The current timeout set i.e, 0.5sec (100*1000 usec * 5 iterations) is at time not sufficient. So, increase the number of iterations to 50  which results in overal timeout of 5 sec.